### PR TITLE
Fix apt lock conflicts during Codespaces dotfiles installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ fi
 
 echo "DOTFILES_DIR=${DOTFILES_DIR}"
 source "${DOTFILES_DIR}/script/log.sh"
+source "${DOTFILES_DIR}/script/wait-for-apt.sh"
 
 mkdir -p "${HOME}/.config"
 banner "ENV"
@@ -28,6 +29,11 @@ function symlink {
 }
 
 banner "apt-get"
+
+# Wait for any existing apt processes to complete before running our updates
+wait_for_apt_lock || {
+  echo "Failed to acquire apt lock within timeout, but continuing anyway..."
+}
 
 sudo apt-get update
 sudo apt-get -y install build-essential

--- a/script/wait-for-apt.sh
+++ b/script/wait-for-apt.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Wait for apt locks to be released
+# This is needed in Codespaces where background apt processes may be running
+
+wait_for_apt_lock() {
+  local max_wait=300  # 5 minutes
+  local wait_interval=5
+  local elapsed=0
+  
+  info "Checking for apt locks..."
+  
+  while sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || \
+        sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || \
+        sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1; do
+    
+    if [ $elapsed -ge $max_wait ]; then
+      echo "WARNING: Timeout waiting for apt locks after ${max_wait}s, proceeding anyway..."
+      return 1
+    fi
+    
+    info "Waiting for apt locks to be released... (${elapsed}s elapsed)"
+    sleep $wait_interval
+    elapsed=$((elapsed + wait_interval))
+  done
+  
+  info "Apt locks are free, proceeding..."
+  return 0
+}


### PR DESCRIPTION
## Problem

When Codespaces starts up, dotfiles installation fails with apt lock errors:

```
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 338 (apt-get)
E: Unable to lock directory /var/lib/apt/lists/
```

This happens because the devcontainer is still running background package installations when the dotfiles `install.sh` script tries to run `apt-get update`.

## Solution

Added `script/wait-for-apt.sh` that polls for apt locks and waits up to 5 minutes for them to be released. The `install.sh` script now sources this helper and calls `wait_for_apt_lock()` before running any apt-get commands.

## Changes

- **Added**: `script/wait-for-apt.sh` - Helper script with `wait_for_apt_lock()` function
- **Modified**: `install.sh` - Source the helper script and wait for apt locks before running apt-get

## Testing

The fix checks for locks on:
- `/var/lib/apt/lists/lock`
- `/var/lib/dpkg/lock-frontend`
- `/var/lib/dpkg/lock`

It polls every 5 seconds with informative output and has a 5-minute timeout. If the timeout is reached, it logs a warning but continues anyway (to avoid blocking indefinitely).